### PR TITLE
Add navigation scaffold and auth context

### DIFF
--- a/context/AuthContext.tsx
+++ b/context/AuthContext.tsx
@@ -1,0 +1,32 @@
+import React, { createContext, useContext, useState, ReactNode } from 'react';
+
+type User = { uid: string } | null;
+
+interface AuthContextProps {
+  user: User;
+  login: (uid: string) => void;
+  logout: () => void;
+}
+
+const AuthContext = createContext<AuthContextProps | undefined>(undefined);
+
+export const AuthProvider = ({ children }: { children: ReactNode }) => {
+  const [user, setUser] = useState<User>(null);
+
+  const login = (uid: string) => setUser({ uid });
+  const logout = () => setUser(null);
+
+  return (
+    <AuthContext.Provider value={{ user, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};
+
+export const useAuth = () => {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error('useAuth must be used within AuthProvider');
+  }
+  return context;
+};

--- a/navigation/RootNavigator.tsx
+++ b/navigation/RootNavigator.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { View, Text } from 'react-native';
+
+const Stack = createNativeStackNavigator();
+
+function HomeScreen() {
+  return (
+    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+      <Text>Home Screen</Text>
+    </View>
+  );
+}
+
+export default function RootNavigator() {
+  return (
+    <Stack.Navigator>
+      <Stack.Screen name="Home" component={HomeScreen} />
+    </Stack.Navigator>
+  );
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,10 @@
 {
   "extends": "expo/tsconfig.base",
   "compilerOptions": {
-    "strict": true
+    "strict": true,
+    "baseUrl": "./",
+    "paths": {
+      "@/*": ["*"]
+    }
   }
 }


### PR DESCRIPTION
## Summary
- configure TypeScript path alias for root imports
- add RootNavigator with a basic home screen
- implement AuthContext provider and hook

## Testing
- `npx tsc --noEmit && echo "tsc successful"`
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a8a416ab388329a4dfeef3a6da0cea