### PR TITLE
feat: add interests screen and navigation types

### DIFF
--- a/src/navigation/RootNavigator.tsx
+++ b/src/navigation/RootNavigator.tsx
@@ -1,15 +1,19 @@
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import LoginScreen from '../screens/LoginScreen';
-//import InterestsScreen from '../screens/InterestsScreen';
-//import MatchScreen from '../screens/MatchScreen';
-//import ChatScreen from '../screens/ChatScreen';
+import InterestsScreen from '../screens/InterestsScreen';
 
-const Stack = createNativeStackNavigator();
+export type RootStackParamList = {
+  Login: undefined;
+  Interests: undefined;
+};
+
+const Stack = createNativeStackNavigator<RootStackParamList>();
 
 export default function RootNavigator() {
   return (
     <Stack.Navigator screenOptions={{ headerShown: false }}>
       <Stack.Screen name="Login" component={LoginScreen} />
+      <Stack.Screen name="Interests" component={InterestsScreen} />
     </Stack.Navigator>
   );
 }

--- a/src/screens/InterestsScreen.tsx
+++ b/src/screens/InterestsScreen.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { View, Text } from 'react-native';
+
+export default function InterestsScreen() {
+  return (
+    <View style={{ flex:1, alignItems:'center', justifyContent:'center' }}>
+      <Text>Interesses</Text>
+    </View>
+  );
+}

--- a/src/screens/LoginScreen.tsx
+++ b/src/screens/LoginScreen.tsx
@@ -3,12 +3,16 @@ import { View, Text, TouchableOpacity, ActivityIndicator } from 'react-native';
 import * as WebBrowser from 'expo-web-browser';
 import * as Google from 'expo-auth-session/providers/google';
 import { GoogleAuthProvider, signInWithCredential, signInWithEmailAndPassword, createUserWithEmailAndPassword } from 'firebase/auth';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { auth } from '../services/firebase';
 import { useAuth } from '../context/AuthContext';
+import { RootStackParamList } from '../navigation/RootNavigator';
 
 WebBrowser.maybeCompleteAuthSession();
 
-export default function LoginScreen({ navigation }: any) {
+type LoginScreenNavigation = NativeStackNavigationProp<RootStackParamList, 'Login'>;
+
+export default function LoginScreen({ navigation }: { navigation: LoginScreenNavigation }) {
   const { user, loading } = useAuth();
 
   const [request, response, promptAsync] = Google.useAuthRequest({


### PR DESCRIPTION
## Summary
- add stack param list and typed navigation
- create basic InterestsScreen and register in navigator

## Testing
- `npx tsc --noEmit`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a8ae5d62148329bb2afd0a5fd05837