### PR TITLE
feat: add auth-aware navigation flow

### DIFF
--- a/src/navigation/RootNavigator.tsx
+++ b/src/navigation/RootNavigator.tsx
@@ -1,6 +1,8 @@
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { ActivityIndicator, View } from 'react-native';
 import LoginScreen from '../screens/LoginScreen';
 import InterestsScreen from '../screens/InterestsScreen';
+import { useAuth } from '../context/AuthContext';
 
 export type RootStackParamList = {
   Login: undefined;
@@ -10,10 +12,23 @@ export type RootStackParamList = {
 const Stack = createNativeStackNavigator<RootStackParamList>();
 
 export default function RootNavigator() {
+  const { user, loading } = useAuth();
+
+  if (loading) {
+    return (
+      <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+        <ActivityIndicator />
+      </View>
+    );
+  }
+
   return (
     <Stack.Navigator screenOptions={{ headerShown: false }}>
-      <Stack.Screen name="Login" component={LoginScreen} />
-      <Stack.Screen name="Interests" component={InterestsScreen} />
+      {user ? (
+        <Stack.Screen name="Interests" component={InterestsScreen} />
+      ) : (
+        <Stack.Screen name="Login" component={LoginScreen} />
+      )}
     </Stack.Navigator>
   );
 }

--- a/src/screens/LoginScreen.tsx
+++ b/src/screens/LoginScreen.tsx
@@ -1,21 +1,15 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { View, Text, TextInput, TouchableOpacity, ActivityIndicator, Alert } from 'react-native';
 import { createUserWithEmailAndPassword, signInWithEmailAndPassword, signInAnonymously } from 'firebase/auth';
 import { doc, setDoc, serverTimestamp } from 'firebase/firestore';
 import { auth, db } from '../services/firebase';
 import { useAuth } from '../context/AuthContext';
 
-export default function LoginScreen({ navigation }: any) {
-  const { user, loading } = useAuth();
+export default function LoginScreen() {
+  const { loading } = useAuth();
   const [email, setEmail] = useState('');
   const [pass, setPass] = useState('');
   const [busy, setBusy] = useState(false);
-
-  useEffect(() => {
-    if (!loading && user) {
-      navigation.replace('Interests');
-    }
-  }, [user, loading]);
 
   const ensureUserDoc = async (uid: string) => {
     const ref = doc(db, 'users', uid);


### PR DESCRIPTION
## Summary
- show loading indicator while auth state initializes
- route logged-in users to Interests and guests to Login
- simplify LoginScreen to rely on context-driven navigation

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a8e9fa245c8329ab9def43bf20e49a