### PR TITLE
Add missing navigation routes for match and chat

### DIFF
--- a/src/navigation/RootNavigator.tsx
+++ b/src/navigation/RootNavigator.tsx
@@ -2,11 +2,15 @@ import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { ActivityIndicator, View } from 'react-native';
 import LoginScreen from '../screens/LoginScreen';
 import InterestsScreen from '../screens/InterestsScreen';
+import MatchScreen from '../screens/MatchScreen';
+import ChatScreen from '../screens/ChatScreen';
 import { useAuth } from '../context/AuthContext';
 
 export type RootStackParamList = {
   Login: undefined;
   Interests: undefined;
+  Match: undefined;
+  Chat: { matchId: string };
 };
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
@@ -25,7 +29,11 @@ export default function RootNavigator() {
   return (
     <Stack.Navigator screenOptions={{ headerShown: false }}>
       {user ? (
-        <Stack.Screen name="Interests" component={InterestsScreen} />
+        <>
+          <Stack.Screen name="Interests" component={InterestsScreen} />
+          <Stack.Screen name="Match" component={MatchScreen} />
+          <Stack.Screen name="Chat" component={ChatScreen} />
+        </>
       ) : (
         <Stack.Screen name="Login" component={LoginScreen} />
       )}


### PR DESCRIPTION
## Summary
- Add Match and Chat screens to root navigator
- Define navigation params for Match and Chat

## Testing
- `npm test` (fails: Missing script "test")
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_68a8efcbbd6c8329bd945249dafa8d9f