### PR TITLE
fix: narrow match candidate type

### DIFF
--- a/src/screens/MatchScreen.tsx
+++ b/src/screens/MatchScreen.tsx
@@ -83,15 +83,16 @@ export default function MatchScreen({ navigation }: any) {
       }
 
       // STEP 4 — criar/reutilizar o match
-      const mid = deterministicMatchId(uid, best.uid);
+      const bestMatch = best as Best;
+      const mid = deterministicMatchId(uid, bestMatch.uid);
       try {
         const mref = doc(db, 'matches', mid);
         const exists = await getDoc(mref);
         if (!exists.exists()) {
           await setDoc(mref, {
-            participants: [uid, best.uid],
-            sharedInterests: best.shared,
-            unlocked: { [uid]: false, [best.uid]: false },
+            participants: [uid, bestMatch.uid],
+            sharedInterests: bestMatch.shared,
+            unlocked: { [uid]: false, [bestMatch.uid]: false },
             createdAt: serverTimestamp(),
             mode: '1to1',
           });


### PR DESCRIPTION
## Summary
- fix TypeScript error by asserting candidate match type

## Testing
- `npx tsc -p . --noEmit`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a9a81801448329975228c5e6b468ce