### PR TITLE
Improve navigation performance

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -3,7 +3,11 @@ import { NavigationContainer } from '@react-navigation/native';
 import RootNavigator from './src/navigation/RootNavigator';
 import { StatusBar } from 'expo-status-bar';
 import { SafeAreaView, StyleSheet } from 'react-native';
+import { enableScreens } from 'react-native-screens';
 import { AuthProvider } from './src/context/AuthContext';
+
+// Enable native screens for better performance
+enableScreens();
 
 export default function App() {
   return (

--- a/src/screens/InterestsScreen.tsx
+++ b/src/screens/InterestsScreen.tsx
@@ -9,6 +9,7 @@ import {
   SafeAreaView,
   TextInput,
   ScrollView,
+  InteractionManager,
 } from 'react-native';
 import { useBottomTabBarHeight } from '@react-navigation/bottom-tabs';
 import { Ionicons } from '@expo/vector-icons';
@@ -121,43 +122,46 @@ export default function InterestsScreen({ navigation }: any) {
   // ---------- load on mount ----------
   useEffect(() => {
     let mounted = true;
-    (async () => {
-      try {
-        // 1) app_config / limite
+    const task = InteractionManager.runAfterInteractions(() => {
+      (async () => {
         try {
-          const cfgSnap = await getDoc(doc(db, 'app_config', 'general'));
-          const cfg = (cfgSnap.exists() ? (cfgSnap.data() as AppConfig) : {}) || {};
-          if (cfg.maxInterests && typeof cfg.maxInterests === 'number') {
-            setMaxInterests(cfg.maxInterests);
+          // 1) app_config / limite
+          try {
+            const cfgSnap = await getDoc(doc(db, 'app_config', 'general'));
+            const cfg = (cfgSnap.exists() ? (cfgSnap.data() as AppConfig) : {}) || {};
+            if (cfg.maxInterests && typeof cfg.maxInterests === 'number') {
+              setMaxInterests(cfg.maxInterests);
+            }
+          } catch (e) {
+            // ignore, usa default
+          }
+
+          // 2) interesses
+          const list = await seedIfEmpty();
+          if (!mounted) return;
+          setItems(list);
+
+          // 3) selecionados do user
+          try {
+            const uSnap = await getDoc(doc(db, 'users', uid));
+            const u = uSnap.exists() ? (uSnap.data() as any) : null;
+            const my = (u?.interests as string[]) || [];
+            setSelected(my);
+            setInitialSelected(my);
+          } catch (e) {
+            // ignore
           }
         } catch (e) {
-          // ignore, usa default
+          console.error(e);
+          Alert.alert('Erro', 'Não foi possível carregar os interesses.');
+        } finally {
+          if (mounted) setLoading(false);
         }
-
-        // 2) interesses
-        const list = await seedIfEmpty();
-        if (!mounted) return;
-        setItems(list);
-
-        // 3) selecionados do user
-        try {
-          const uSnap = await getDoc(doc(db, 'users', uid));
-          const u = uSnap.exists() ? (uSnap.data() as any) : null;
-          const my = (u?.interests as string[]) || [];
-          setSelected(my);
-          setInitialSelected(my);
-        } catch (e) {
-          // ignore
-        }
-      } catch (e) {
-        console.error(e);
-        Alert.alert('Erro', 'Não foi possível carregar os interesses.');
-      } finally {
-        if (mounted) setLoading(false);
-      }
-    })();
+      })();
+    });
     return () => {
       mounted = false;
+      task.cancel();
     };
   }, [uid, seedIfEmpty]);
 


### PR DESCRIPTION
## Summary
- enable native screens to speed up navigation
- defer interest loading and match setup until after interactions

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b0621465908329b29d6daae309a8d2