### PR TITLE
Resolve TypeScript errors in match and interests screens

### DIFF
--- a/src/screens/InterestsChip.tsx
+++ b/src/screens/InterestsChip.tsx
@@ -43,7 +43,7 @@ export default function InterestChip({
   style,
   textStyle,
 }: InterestChipProps) {
-  const S = size === 'sm' ? styles.sm : styles.md;
+  const S = sizeStyles[size];
 
   return (
     <TouchableOpacity
@@ -103,6 +103,9 @@ const styles = StyleSheet.create({
   text: {
     fontWeight: '700',
   },
+});
+
+const sizeStyles: Record<Size, { container: ViewStyle; text: TextStyle }> = {
   sm: {
     container: { paddingVertical: 6 },
     text: { fontSize: 11 },
@@ -111,4 +114,4 @@ const styles = StyleSheet.create({
     container: { paddingVertical: 8 },
     text: { fontSize: 12 },
   },
-}) as const;
+};

--- a/src/screens/MatchScreen.tsx
+++ b/src/screens/MatchScreen.tsx
@@ -1,6 +1,11 @@
 // src/screens/MatchScreen.tsx
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import {
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  useRef,
+} from 'react';
 import {
   View,
   Text,
@@ -10,27 +15,8 @@ import {
   SafeAreaView,
   Image,
   ScrollView,
+  InteractionManager,
 } from 'react-native';
-import { useBottomTabBarHeight } from '@react-navigation/bottom-tabs';
-import { InteractionManager } from 'react-native';
-import { auth, db } from '../services/firebase';
-import {
-  collection,
-  query,
-  where,
-  orderBy,
-  limit,
-  getDocs,
-  setDoc,
-  doc,
-  runTransaction,
-} from 'firebase/firestore';
-let isEqual;
-try {
-  isEqual = require('fast-deep-equal');
-} catch {
-  isEqual = (a, b) => JSON.stringify(a) === JSON.stringify(b);
-}
 import { useBottomTabBarHeight } from '@react-navigation/bottom-tabs';
 import { Ionicons } from '@expo/vector-icons';
 import { auth, db } from '../services/firebase';
@@ -46,9 +32,18 @@ import {
   runTransaction,
   serverTimestamp,
   setDoc,
-  updateDoc,
   where,
 } from 'firebase/firestore';
+
+// Fallback helper to compare arrays without pulling in an additional
+// dependency at runtime. If `fast-deep-equal` is present it will be used.
+let isEqual: (a: unknown, b: unknown) => boolean;
+try {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  isEqual = require('fast-deep-equal');
+} catch {
+  isEqual = (a, b) => JSON.stringify(a) === JSON.stringify(b);
+}
 
 type UserDoc = {
   displayName?: string;


### PR DESCRIPTION
## Summary
- Clean up duplicated imports and add a safe deep-equal fallback in `MatchScreen`
- Refactor `InterestChip` styles and use typed size helpers
- Fix missing imports, naming conflicts and InterestChip usage in `InterestsScreen`

## Testing
- `npm run typecheck`
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*


------
https://chatgpt.com/codex/tasks/task_e_68b074a9f1388329840ce48fd64b64a7