### PR TITLE
chore: memoize interest chips to improve performance

### DIFF
--- a/src/screens/InterestsChip.tsx
+++ b/src/screens/InterestsChip.tsx
@@ -31,7 +31,7 @@ export type InterestChipProps = {
  * - Tamanhos: sm/md
  * - Mostra #label por padrão (showHash)
  */
-export default function InterestChip({
+function InterestChip({
   label,
   active = false,
   disabled = false,
@@ -83,6 +83,8 @@ export default function InterestChip({
     </TouchableOpacity>
   );
 }
+
+export default React.memo(InterestChip);
 
 const COLORS = {
   text: '#e5e7eb',

--- a/src/screens/InterestsScreen.tsx
+++ b/src/screens/InterestsScreen.tsx
@@ -51,6 +51,34 @@ type AppConfig = {
   maxInterests?: number;
 };
 
+const Chip = React.memo(function Chip({
+  active,
+  label,
+  onPress,
+}: {
+  active?: boolean;
+  label: string;
+  onPress?: () => void;
+}) {
+  return (
+    <TouchableOpacity
+      onPress={onPress}
+      style={{
+        paddingHorizontal: 12,
+        paddingVertical: 8,
+        borderRadius: 999,
+        borderWidth: 1,
+        borderColor: active ? COLORS.brand : COLORS.border,
+        backgroundColor: active ? 'rgba(124,58,237,0.12)' : 'rgba(255,255,255,0.04)',
+        marginRight: 8,
+        marginBottom: 8,
+      }}
+    >
+      <Text style={{ color: active ? '#fff' : COLORS.text, fontWeight: '700', fontSize: 12 }}>#{label}</Text>
+    </TouchableOpacity>
+  );
+});
+
 export default function InterestsScreen({ navigation }: any) {
   const uid = auth.currentUser?.uid!;
   const tabBarHeight = useBottomTabBarHeight();
@@ -213,23 +241,6 @@ export default function InterestsScreen({ navigation }: any) {
   }, [uid, changed, selected]);
 
   // ---------- UI ----------
-  const Chip = ({ active, label, onPress }: { active?: boolean; label: string; onPress?: () => void }) => (
-    <TouchableOpacity
-      onPress={onPress}
-      style={{
-        paddingHorizontal: 12,
-        paddingVertical: 8,
-        borderRadius: 999,
-        borderWidth: 1,
-        borderColor: active ? COLORS.brand : COLORS.border,
-        backgroundColor: active ? 'rgba(124,58,237,0.12)' : 'rgba(255,255,255,0.04)',
-        marginRight: 8,
-        marginBottom: 8,
-      }}
-    >
-      <Text style={{ color: active ? '#fff' : COLORS.text, fontWeight: '700', fontSize: 12 }}>#{label}</Text>
-    </TouchableOpacity>
-  );
 
   if (loading) {
     return (


### PR DESCRIPTION
## Summary
- memoize reusable interest chip component
- extract and memoize category Chip to avoid unnecessary re-renders

## Testing
- `npm run lint` *(fails: eslint: not found)*
- `npm install eslint@8 --no-save` *(fails: 403 Forbidden - cannot access registry)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b0775718c083299d4535f7ffd1329a