### PR TITLE
perf: optimize interest filtering and chip rendering

### DIFF
--- a/src/screens/InterestsChip.tsx
+++ b/src/screens/InterestsChip.tsx
@@ -31,7 +31,7 @@ export type InterestChipProps = {
  * - Tamanhos: sm/md
  * - Mostra #label por padrão (showHash)
  */
-export default function InterestChip({
+function InterestChip({
   label,
   active = false,
   disabled = false,
@@ -83,6 +83,8 @@ export default function InterestChip({
     </TouchableOpacity>
   );
 }
+
+export default React.memo(InterestChip);
 
 const COLORS = {
   text: '#e5e7eb',


### PR DESCRIPTION
## Summary
- memoize reusable interest chip component
- extract and memoize category Chip to avoid unnecessary re-renders
- cache interests per category and reuse during filtering

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration; repository missing eslint.config.js)*
- `npm install eslint@8 --no-save` *(fails: 403 Forbidden - cannot access registry)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b0775718c083299d4535f7ffd1329a