### PR TITLE
feat: improve Firestore connectivity

### DIFF
--- a/src/services/firebase.ts
+++ b/src/services/firebase.ts
@@ -43,7 +43,9 @@ export const auth =
 const isWeb = Platform.OS === 'web';
 const _db = initializeFirestore(app, {
   localCache: isWeb ? persistentLocalCache() : memoryLocalCache(),
-  ...(isWeb ? {} : { experimentalForceLongPolling: true, useFetchStreams: false }),
+  ...(isWeb
+    ? { experimentalAutoDetectLongPolling: true }
+    : { experimentalForceLongPolling: true, useFetchStreams: false }),
 } as any);
 
 // Reduz verbosidade de logs (menos custo no bridge)


### PR DESCRIPTION
## Summary
- tweak Firestore initialization to auto-detect long polling on web clients

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.* file)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b0840bafd48329a5741604132a35d3