### PR TITLE
Improve Firestore offline handling

### DIFF
--- a/src/services/firebase.ts
+++ b/src/services/firebase.ts
@@ -38,11 +38,20 @@ export const auth =
         persistence: getReactNativePersistence(AsyncStorage),
       });
 
-// Firestore com cache local persistente quando suportado.
-// Em ambientes nativos, force long polling para estabilizar a ligação.
+// Firestore com cache local persistente para acesso offline.
+// Em React Native forçamos long polling para maior compatibilidade.
 const isWeb = Platform.OS === 'web';
+let localCache;
+try {
+  // Tenta persistência em disco (AsyncStorage / IndexedDB).
+  localCache = persistentLocalCache();
+} catch (_) {
+  // Fallback para cache em memória caso a persistência não esteja disponível.
+  localCache = memoryLocalCache();
+}
+
 const _db = initializeFirestore(app, {
-  localCache: isWeb ? persistentLocalCache() : memoryLocalCache(),
+  localCache,
   ...(isWeb
     ? { experimentalAutoDetectLongPolling: true }
     : { experimentalForceLongPolling: true, useFetchStreams: false }),


### PR DESCRIPTION
## Summary
- ensure Firestore uses persistent local cache on React Native with fallback to memory
- load profile data from Firestore cache when network request fails

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run typecheck`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68b0873866908329a2eaa9e26e6d7edf