### PR TITLE
Allow authenticated reads of match queue

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,17 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    function isSignedIn() {
+      return request.auth != null;
+    }
+    function uid() {
+      return request.auth != null ? request.auth.uid : null;
+    }
+
+    match /match_queue/{userId} {
+      allow read: if isSignedIn();
+      allow write: if isSignedIn() && userId == uid();
+    }
+    // TODO: outras regras aqui
+  }
+}


### PR DESCRIPTION
## Summary
- allow signed-in users to read match queue documents
- restrict writes to owner of queue entry

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run typecheck`
- `npm install -g firebase-tools` *(fails: 403 Forbidden)*
- `node testFetchBestCandidate.js` *(fails: auth/network-request-failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b09776553c8329bfcb57b8cbec065a