### PR TITLE
fix: avoid forced offline in Firestore

### DIFF
--- a/src/hooks/useNetwork.ts
+++ b/src/hooks/useNetwork.ts
@@ -1,8 +1,8 @@
 import { useEffect, useState } from 'react';
 import NetInfo from '@react-native-community/netinfo';
-import { Firestore, disableNetwork, enableNetwork } from 'firebase/firestore';
+import { Firestore } from 'firebase/firestore';
 
-export default function useNetwork(db?: Firestore) {
+export default function useNetwork(_db?: Firestore) {
   const [isConnected, setIsConnected] = useState(true);
 
   useEffect(() => {
@@ -18,15 +18,6 @@ export default function useNetwork(db?: Firestore) {
 
     return () => unsubscribe();
   }, []);
-
-  useEffect(() => {
-    if (!db) return;
-    if (isConnected) {
-      enableNetwork(db).catch(() => {});
-    } else {
-      disableNetwork(db).catch(() => {});
-    }
-  }, [db, isConnected]);
 
   return { isConnected };
 }


### PR DESCRIPTION
## Summary
- stop toggling Firestore network in useNetwork hook to prevent offline errors

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run typecheck` *(fails: Cannot use JSX unless the '--jsx' flag is provided; missing expo tsconfig)*

------
https://chatgpt.com/codex/tasks/task_e_68b09e1ad27c83298b64b10a4082cb11