### PR TITLE
refactor: centralize color palette

### DIFF
--- a/src/navigation/TabNavigator.tsx
+++ b/src/navigation/TabNavigator.tsx
@@ -11,14 +11,7 @@ import ProfileScreen from '../screens/ProfileScreen';
 import { useAuth } from '../context/AuthContext';
 import { db } from '../services/firebase';
 import { collection, onSnapshot, orderBy, query, where, limit } from 'firebase/firestore';
-
-const COLORS = {
-  bg: '#0f172a',
-  text: '#e5e7eb',
-  sub: '#9ca3af',
-  border: 'rgba(255,255,255,0.15)',
-  brand: '#7c3aed',
-};
+import { COLORS } from '../utils/colors';
 
 const Tab = createBottomTabNavigator();
 

--- a/src/screens/InterestsChip.tsx
+++ b/src/screens/InterestsChip.tsx
@@ -9,6 +9,7 @@ import {
   ViewStyle,
   TextStyle,
 } from 'react-native';
+import { COLORS } from '../utils/colors';
 
 type Size = 'sm' | 'md';
 
@@ -85,12 +86,6 @@ function InterestChip({
 }
 
 export default React.memo(InterestChip);
-
-const COLORS = {
-  text: '#e5e7eb',
-  border: 'rgba(255,255,255,0.15)',
-  brand: '#7c3aed',
-};
 
 const styles = StyleSheet.create({
   base: {

--- a/src/screens/InterestsScreen.tsx
+++ b/src/screens/InterestsScreen.tsx
@@ -35,18 +35,7 @@ import {
   serverTimestamp,
 } from 'firebase/firestore';
 import { INTERESTS_SEED, Interest } from '../utils/interestsSeed';
-
-const COLORS = {
-  bg: '#0f172a',
-  text: '#e5e7eb',
-  sub: '#9ca3af',
-  border: 'rgba(255,255,255,0.15)',
-  brand: '#7c3aed',
-  card: 'rgba(255,255,255,0.06)',
-  input: 'rgba(255,255,255,0.08)',
-  danger: '#fb7185',
-  ok: '#10b981',
-};
+import { COLORS } from '../utils/colors';
 
 type AppConfig = {
   maxInterests?: number;

--- a/src/screens/LoginScreen.tsx
+++ b/src/screens/LoginScreen.tsx
@@ -9,12 +9,7 @@ import { Ionicons } from '@expo/vector-icons';
 import { signInWithEmailAndPassword, sendPasswordResetEmail } from 'firebase/auth';
 import { auth } from '../services/firebase';
 import { useAuth } from '../context/AuthContext';
-
-const COLORS = {
-  bg1: '#0f172a', bg2: '#111827', brandA: '#7c3aed',
-  card: 'rgba(255,255,255,0.06)', text: '#e5e7eb', sub: '#9ca3af',
-  error: '#fb7185', input: 'rgba(255,255,255,0.08)', border: 'rgba(255,255,255,0.15)', white: '#fff',
-};
+import { COLORS } from '../utils/colors';
 
 const isValidEmail = (v: string) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(v);
 
@@ -109,7 +104,7 @@ export default function LoginScreen({ navigation }: any) {
                 <TouchableOpacity
                   onPress={handleLogin}
                   disabled={!canLogin || busy}
-                  style={{ backgroundColor: (!canLogin || busy) ? '#3f3f46' : COLORS.brandA, paddingVertical: 14, borderRadius: 12, alignItems: 'center' }}
+                  style={{ backgroundColor: (!canLogin || busy) ? '#3f3f46' : COLORS.brand, paddingVertical: 14, borderRadius: 12, alignItems: 'center' }}
                 >
                   {busy ? <ActivityIndicator color={COLORS.white} /> : <Text style={{ color: COLORS.white, fontWeight: '800' }}>Entrar</Text>}
                 </TouchableOpacity>

--- a/src/screens/MatchScreen.tsx
+++ b/src/screens/MatchScreen.tsx
@@ -37,6 +37,7 @@ import {
   setDoc,
   where,
 } from 'firebase/firestore';
+import { COLORS } from '../utils/colors';
 
 // Fallback helper to compare arrays without pulling in an additional
 // dependency at runtime. If `fast-deep-equal` is present it will be used.
@@ -71,16 +72,6 @@ type Candidate = {
   profile: UserDoc;
 };
 
-const COLORS = {
-  bg: '#0f172a',
-  text: '#e5e7eb',
-  sub: '#9ca3af',
-  border: 'rgba(255,255,255,0.15)',
-  brand: '#7c3aed',
-  card: 'rgba(255,255,255,0.06)',
-  danger: '#fb7185',
-  ok: '#10b981',
-};
 
 const MAX_INTERESTS_MATCH = 10; // para queries com array-contains-any
 const MAX_INTERESTS = 30; // ajusta ao teu limite

--- a/src/screens/ProfileScreen.tsx
+++ b/src/screens/ProfileScreen.tsx
@@ -24,6 +24,7 @@ import { doc, setDoc, serverTimestamp } from 'firebase/firestore';
 import { useAuth } from '../context/AuthContext';
 import { ref, uploadBytes, getDownloadURL } from 'firebase/storage';
 import useNetwork from '../hooks/useNetwork';
+import { COLORS } from '../utils/colors';
 
 type UserDoc = {
   nickname?: string;
@@ -38,18 +39,6 @@ type UserDoc = {
   updatedAt?: any;
 };
 
-const COLORS = {
-  bg: '#0f172a',
-  text: '#e5e7eb',
-  sub: '#9ca3af',
-  border: 'rgba(255,255,255,0.15)',
-  brand: '#7c3aed',
-  card: 'rgba(255,255,255,0.06)',
-  input: 'rgba(255,255,255,0.08)',
-  danger: '#fb7185',
-  ok: '#10b981',
-  line: '#233047',
-};
 
 export default function ProfileScreen() {
   const navigation = useNavigation<any>();

--- a/src/screens/SignUpScreen.tsx
+++ b/src/screens/SignUpScreen.tsx
@@ -5,12 +5,7 @@ import { Ionicons } from '@expo/vector-icons';
 import { createUserWithEmailAndPassword } from 'firebase/auth';
 import { auth, db } from '../services/firebase';
 import { doc, setDoc, serverTimestamp } from 'firebase/firestore';
-
-const COLORS = {
-  bg1: '#0f172a', bg2: '#111827', brandA: '#7c3aed',
-  card: 'rgba(255,255,255,0.06)', text: '#e5e7eb', sub: '#9ca3af',
-  error: '#fb7185', input: 'rgba(255,255,255,0.08)', border: 'rgba(255,255,255,0.15)', white: '#fff',
-};
+import { COLORS } from '../utils/colors';
 
 const isValidEmail = (v: string) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(v);
 const pwOK = (p: string) => p.length >= 6;
@@ -127,7 +122,7 @@ export default function SignUpScreen({ navigation }: any) {
                 <TouchableOpacity
                   onPress={handleCreate}
                   disabled={!(emailOk && passOk && confirmOk) || busy}
-                  style={{ backgroundColor: (!(emailOk && passOk && confirmOk) || busy) ? 'rgba(255,255,255,0.25)' : COLORS.brandA, paddingVertical: 14, borderRadius: 12, alignItems: 'center', marginTop: 16 }}
+                  style={{ backgroundColor: (!(emailOk && passOk && confirmOk) || busy) ? 'rgba(255,255,255,0.25)' : COLORS.brand, paddingVertical: 14, borderRadius: 12, alignItems: 'center', marginTop: 16 }}
                 >
                   {busy ? <ActivityIndicator color={COLORS.white} /> : <Text style={{ color: COLORS.white, fontWeight: '800' }}>Criar conta</Text>}
                 </TouchableOpacity>

--- a/src/utils/colors.ts
+++ b/src/utils/colors.ts
@@ -1,0 +1,16 @@
+export const COLORS = {
+  bg1: '#0f172a',
+  bg2: '#111827',
+  bg: '#0f172a',
+  brand: '#7c3aed',
+  card: 'rgba(255,255,255,0.06)',
+  text: '#e5e7eb',
+  sub: '#9ca3af',
+  error: '#fb7185',
+  danger: '#fb7185',
+  input: 'rgba(255,255,255,0.08)',
+  border: 'rgba(255,255,255,0.15)',
+  white: '#fff',
+  ok: '#10b981',
+  line: '#233047',
+};


### PR DESCRIPTION
## Summary
- share color constants via src/utils/colors
- replace duplicated COLORS definitions across screens

## Testing
- `npm run lint` (fails: cannot find package '@eslint/js')
- `npm run typecheck` (fails: missing modules)

------
https://chatgpt.com/codex/tasks/task_e_68b0c56aa0048329a6e29c1e89bedf43